### PR TITLE
Fix deployment on MacOS

### DIFF
--- a/framebuffers.asd
+++ b/framebuffers.asd
@@ -9,7 +9,7 @@
   :source-control (:git "https://github.com/shirakumo/framebuffers.git")
   :defsystem-depends-on (:trivial-features)
   :depends-on (:framebuffers/protocol
-               (:feature :unix :framebuffers/xlib)
+               (:feature (:and :unix (:not :darwin)) :framebuffers/xlib)
                (:feature :windows :framebuffers/win32)
                (:feature :linux :framebuffers/wayland)
                (:feature :darwin :framebuffers/cocoa)


### PR DESCRIPTION
Hey! Framebuffers do compile and load on MacOS, but when trying to use Deploy it fails trying to find XLib libraries, which I believe are not present on MacOS. This PR fixes it.