### PR TITLE
Use the cl-user::*foreign-system-libraries* hook

### DIFF
--- a/wayland/bindings.lisp
+++ b/wayland/bindings.lisp
@@ -8,6 +8,11 @@
   (:linux (:or (:default "libxkbcommon") "libxkbcommon.so.0"))
   (T (:or (:default "libxkbcommon") (:default "xkbcommon"))))
 
+(set 'cl-user::*foreign-system-libraries*
+      (union (when (boundp 'cl-user::*foreign-system-libraries*)
+               (symbol-value 'cl-user::*foreign-system-libraries*))
+             '(wayland xkbcommon)))
+
 ;;; core defs
 (defconstant MARSHAL-FLAG-DESTROY 1)
 

--- a/win32/bindings.lisp
+++ b/win32/bindings.lisp
@@ -9,6 +9,11 @@
 (cffi:define-foreign-library gdi32
   (T (:default "gdi32")))
 
+(set 'cl-user::*foreign-system-libraries*
+     (union (when (boundp 'cl-user::*foreign-system-libraries*)
+              (symbol-value 'cl-user::*foreign-system-libraries*))
+            '(user32 shcore user32)))
+
 (defconstant ENUM-CURRENT-SETTINGS (ldb (byte 32 0) -1))
 (defconstant ENUM-REGISTRY-SETTINGS (ldb (byte 32 0) -2))
 

--- a/xlib/bindings.lisp
+++ b/xlib/bindings.lisp
@@ -24,6 +24,11 @@
   (:linux (:or (:default "libXi") "libXi.so.6"))
   (T (:or (:default "libXi") (:default "Xi"))))
 
+(set 'cl-user::*foreign-system-libraries*
+     (union (when (boundp 'cl-user::*foreign-system-libraries*)
+              (symbol-value 'cl-user::*foreign-system-libraries*))
+            '(x11 xext xrandr xinerama xcursor xi)))
+
 (cffi:defctype xid :ulong)
 (cffi:defctype atom :ulong)
 


### PR DESCRIPTION
Hey! This PR adds the support for Deploy's `cl-user::*foreign-system-libraries*`, so that the system libraries used by Framebuffers are not deployed with the app.